### PR TITLE
Update src/com/cyanogenmod/updater/receiver/NotificationClickReceiver.java

### DIFF
--- a/src/com/cyanogenmod/updater/receiver/NotificationClickReceiver.java
+++ b/src/com/cyanogenmod/updater/receiver/NotificationClickReceiver.java
@@ -9,22 +9,43 @@
 
 package com.cyanogenmod.updater.receiver;
 
+import android.app.DownloadManager;
+import android.app.DownloadManager.Query;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.database.Cursor;
 
 import com.cyanogenmod.updater.UpdatesSettings;
+import com.cyanogenmod.updater.misc.Constants;
 
 public class NotificationClickReceiver extends BroadcastReceiver{
     private static String TAG = "NotificationClickReceiver";
 
     @Override
     public void onReceive(Context context, Intent intent) {
+        
+    	// Get the ID of the currently running CMUpdater download and the one just finished
+        SharedPreferences prefs = context.getSharedPreferences("CMUpdate", Context.MODE_MULTI_PROCESS);
+        long enqueue = prefs.getLong(Constants.DOWNLOAD_ID, -1);
+        long id = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -2);
 
-        // Bring the main app to the foreground
-        Intent i = new Intent(context, UpdatesSettings.class);
-        i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP | 
-                Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
-        context.startActivity(i);
+        // If we had an active download and the IDs match
+        if (enqueue != -1 && id != -2 && id == enqueue) {
+            Query query = new Query();
+            query.setFilterById(id);
+            DownloadManager dm = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
+            Cursor c = dm.query(query);
+            if (c.moveToFirst()) {
+
+		        // Bring the main app to the foreground
+		        Intent i = new Intent(context, UpdatesSettings.class);
+		        i.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_SINGLE_TOP | 
+		                Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+		        context.startActivity(i);
+        
+            }
+        }
     }
 }


### PR DESCRIPTION
Maybe this modification will not block every `BroadcastReceiver` for other `android.intent.action.DOWNLOAD_NOTIFICATION_CLICKED` once that CMupdater has ran at least once.

NOT TESTED. This was just to bring some attention. Sorry for this.

For reference: http://stackoverflow.com/questions/15068353/is-it-possible-that-two-broadcastreceiver-from-two-apps-based-on-the-same-broad
