### PR TITLE
Fix 'not_download_failure' typo in strings.xml

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -73,7 +73,7 @@
     <string name="unable_to_download_file">Unable to download the update file</string>
     <string name="download_not_found">Download not found</string>
     <string name="not_download_success">Update downloaded successfully</string>
-    <string name="not_download_failure">Update download was unsuccessul</string>
+    <string name="not_download_failure">Update download was unsuccessful</string>
     <string name="not_action_install_update">Reboot and install</string>
     <string name="not_download_install_notice">The update <xliff:g id="filename">%s</xliff:g> was successfully downloaded. When touching \'Reboot and install\', the device will restart itself to install the update.\n\nNote: A compatible Recovery is required for the installation to work automatically.</string>
 


### PR DESCRIPTION
The string in 'not_download_failure' contained a typo in the word "unsuccessful".
